### PR TITLE
Use submodule for bson-cxx (master) dependency instead of pulling at project peer level.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bson-cxx"]
 	path = bson-cxx
-	url = git@github.com:dwight/bson-cxx
+	url = git://github.com/dwight/bson-cxx.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bson-cxx"]
+	path = bson-cxx
+	url = git@github.com:dwight/bson-cxx

--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ See the [doc/](doc) folder.
 
 ## Building
 
-You will need the [bson-cxx](https://github.com/dwight/bson-cxx) library (a dependancy) to build the tools.  It is available on github.
-
-Place it as a peer level directory on disk with bsontools.  (That is you will see lines such as `#include "../../../bson-cxx/"` in the source code of these tools...)
+The [bson-cxx](https://github.com/dwight/bson-cxx) library (a dependancy) is added as a submodule to this project and should be availble when building the tools. 
+Initially cloning a repository with --recursive will clone the submodule as well.
 
 To build with scons, assuming it is installed, just type "scons".
 
@@ -43,7 +42,3 @@ Some automated tests would be real helpful for example...
 ## Support
 
 For help try posting to the [BSON Google Groups forum](https://groups.google.com/forum/#!forum/bson).
-
-
-
-

--- a/SConstruct
+++ b/SConstruct
@@ -7,13 +7,13 @@ env.Append(CCFLAGS='-std=c++0x')
 env.Program(target = 'hex', source = ["src/bsontools/hex.cpp"])
 
 dep1 = [
-    "../bson-cxx/src/bson/time_support.cpp",
-    "../bson-cxx/src/bson/bson.cpp",
-    "../bson-cxx/src/bson/parse_number.cpp" ]
+    "bson-cxx/src/bson/time_support.cpp",
+    "bson-cxx/src/bson/bson.cpp",
+    "bson-cxx/src/bson/parse_number.cpp" ]
 
 dep2 = [
-    "../bson-cxx/src/bson/json.cpp",
-    "../bson-cxx/src/bson/base64.cpp"
+    "bson-cxx/src/bson/json.cpp",
+    "bson-cxx/src/bson/base64.cpp"
     ]
 
 env.Program(target = 'fromcsv', source = ["src/bsontools/fromcsv.cpp"] + dep1)

--- a/src/bsontools/bsonmain.cpp
+++ b/src/bsontools/bsonmain.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 #include <fstream>
 #include "binary.h"
-#include "../../../bson-cxx/src/bson/bsonobj.h"
-#include "../../../bson-cxx/src/bson/bsonobjiterator.h"
-#include "../../../bson-cxx/src/bson/bsonobjbuilder.h"
+#include "../../bson-cxx/src/bson/bsonobj.h"
+#include "../../bson-cxx/src/bson/bsonobjiterator.h"
+#include "../../bson-cxx/src/bson/bsonobjbuilder.h"
 #include "cmdline.h"
 #include <deque>
 #include <map>

--- a/src/bsontools/cmdline.h
+++ b/src/bsontools/cmdline.h
@@ -2,7 +2,7 @@
 
 #include <set>
 #include <vector>
-#include "../../../bson-cxx/src/bson/parse_number.h"
+#include "../../bson-cxx/src/bson/parse_number.h"
 
 using namespace _bson;
 using namespace std;

--- a/src/bsontools/fromcsv.cpp
+++ b/src/bsontools/fromcsv.cpp
@@ -2,8 +2,8 @@
 #include "binary.h"
 #include <iostream>
 #include <string>
-#include "../../../bson-cxx/src/bson/json.h"
-#include "../../../bson-cxx/src/bson/bsonobjbuilder.h"
+#include "../../bson-cxx/src/bson/json.h"
+#include "../../bson-cxx/src/bson/bsonobjbuilder.h"
 #include "cmdline.h"
 #include "parse_types.h"
 

--- a/src/bsontools/fromjson.cpp
+++ b/src/bsontools/fromjson.cpp
@@ -5,8 +5,8 @@
 #include <iostream>
 #include <string>
 #include "binary.h"
-#include "../../../bson-cxx/src/bson/json.h"
-#include "../../../bson-cxx/src/bson/bsonobjbuilder.h"
+#include "../../bson-cxx/src/bson/json.h"
+#include "../../bson-cxx/src/bson/bsonobjbuilder.h"
 #include "cmdline.h"
 
 using namespace std;

--- a/src/bsontools/fromxml.cpp
+++ b/src/bsontools/fromxml.cpp
@@ -5,9 +5,9 @@
 #include <iostream>
 #include <string>
 #include "binary.h"
-#include "../../../bson-cxx/src/bson/json.h"
-#include "../../../bson-cxx/src/bson/bsonobjbuilder.h"
-#include "../../../bson-cxx/src/bson/bsonobjiterator.h"
+#include "../../bson-cxx/src/bson/json.h"
+#include "../../bson-cxx/src/bson/bsonobjbuilder.h"
+#include "../../bson-cxx/src/bson/bsonobjiterator.h"
 #include "cmdline.h"
 #include "parse_types.h"
 #include "../util/str.h"

--- a/src/bsontools/hex.cpp
+++ b/src/bsontools/hex.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 #include "stdio.h"
 #include "binary.h"
-#include "../../../bson-cxx/src/bson/hex.h"
-#include "../../../bson-cxx/src/bson/endian.h"
+#include "../../bson-cxx/src/bson/hex.h"
+#include "../../bson-cxx/src/bson/endian.h"
 #include "cmdline.h"
 
 using namespace std;


### PR DESCRIPTION
It may be beneficial to have a submodule within the repository to satisfy the dependency implicitly instead of doing yet another project checkout in outer directory.
