### PR TITLE
Fix undefined reference to parseNumberFromStringWithBase<int>

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4,7 +4,7 @@ env.Append(CCFLAGS='-std=c++0x')
 
 # env.Program(target = 'hex', source = ["src/bsontools/hex.cpp"])
 
-env.Program(target = 'hex', source = ["src/bsontools/hex.cpp"])
+
 
 dep1 = [
     "../bson-cxx/src/bson/time_support.cpp",
@@ -15,6 +15,8 @@ dep2 = [
     "../bson-cxx/src/bson/json.cpp",
     "../bson-cxx/src/bson/base64.cpp"
     ]
+
+env.Program(target = 'hex', source = ["src/bsontools/hex.cpp"] + dep1)
 
 env.Program(target = 'fromcsv', source = ["src/bsontools/fromcsv.cpp"] + dep1)
 


### PR DESCRIPTION
Could not build with scons. It gave the error 
```
src/bsontools/hex.o: In function `_bson::Status _bson::parseNumberFromString<int>(_bson::StringData const&, int*)':
hex.cpp:(.text+0x4c2): undefined reference to `_bson::Status _bson::parseNumberFromStringWithBase<int>(_bson::StringData const&, int, int*)'
```
By adding dep1 hex target the issue is resolved.